### PR TITLE
Fix url to project page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 yahoogroups-grab
 =============
 
-More information about the archiving project can be found on the ArchiveTeam wiki: [Yahoo! Groups](http://archiveteam.org/index.php?title=Yahoo! Groups)
+More information about the archiving project can be found on the ArchiveTeam wiki: [Yahoo! Groups](http://archiveteam.org/index.php?title=Yahoo!_Groups)
 
 Setup instructions
 =========================


### PR DESCRIPTION
The link to the project page is broken as it has a space in the middle of it